### PR TITLE
Update TraceSerializer.py: builder.vtables init to a {}

### DIFF
--- a/python/common/TraceSerializer.py
+++ b/python/common/TraceSerializer.py
@@ -37,7 +37,7 @@ class ImageSerializer:
     self.builder.current_vtable = None
     self.builder.minalign = 1
     self.builder.objectEnd = None
-    self.builder.vtables = []
+    self.builder.vtables = {}
     self.builder.nested = False
     self.builder.finished = False
 


### PR DESCRIPTION
The Builder's `vtables` is a python dict not a list. An error occurs when the flatbuffers  tries to `get` a `vtKey`  

> flatbuffers/builder.py", line 220, in WriteVtable
>     vt2Offset = self.vtables.get(vtKey)
>                 ^^^^^^^^^^^^^^^^
> AttributeError: 'list' object has no attribute 'get'
> 

Maybe we don't see this error before because of the versions
 
I am using spack to install the dependencies, here are the versions I am using:
python@3.11.9
py-tomopy@1.11.0
flatbuffers@24.3.25
py-flatbuffers@23.5.26
py-dxchange@0.1.2
